### PR TITLE
Rename IBiomapperLogRead to IBiomapperRead

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Find the up-to-date contract addresses [here][contract-addresses].
 
 | Contract           | Implemented Interfaces    |
 | ------------------ | ------------------------- |
-| `BiomapperLog`     | [`IBiomapperRead`]        |
+| `Biomapper`        | [`IBiomapperRead`]        |
 | `BridgedBiomapper` | [`IBridgedBiomapperRead`] |
 
 [`IBiomapperRead`]: core/IBiomapperRead.sol/interface.IBiomapperRead.html
@@ -48,7 +48,7 @@ Import the dependencies from the `@biomapper-sdk` like this:
 ```solidity
 import {IBiomapperRead} from "@biomapper-sdk/core/IBiomapperRead.sol";
 import {IBridgedBiomapperRead} from "@biomapper-sdk/core/IBridgedBiomapperRead.sol";
-import {BiomapperLogLib} from "@biomapper-sdk/libraries/BiomapperLogLib.sol";
+import {BiomapperLib} from "@biomapper-sdk/libraries/BiomapperLib.sol";
 ```
 
 ### With Foundry
@@ -64,7 +64,7 @@ Import the dependencies from `biomapper-sdk` like this:
 ```solidity
 import {IBiomapperRead} from "biomapper-sdk/core/IBiomapperRead.sol";
 import {IBridgedBiomapperRead} from "biomapper-sdk/core/IBridgedBiomapperRead.sol";
-import {BiomapperLogLib} from "biomapper-sdk/libraries/BiomapperLogLib.sol";
+import {BiomapperLib} from "biomapper-sdk/libraries/BiomapperLib.sol";
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Find the up-to-date contract addresses [here][contract-addresses].
 
 | Contract           | Implemented Interfaces    |
 | ------------------ | ------------------------- |
-| `BiomapperLog`     | [`IBiomapperLogRead`]     |
+| `BiomapperLog`     | [`IBiomapperRead`]        |
 | `BridgedBiomapper` | [`IBridgedBiomapperRead`] |
 
-[`IBiomapperLogRead`]: core/IBiomapperLogRead.sol/interface.IBiomapperLogRead.html
+[`IBiomapperRead`]: core/IBiomapperRead.sol/interface.IBiomapperRead.html
 [`IBridgedBiomapperRead`]: core/IBridgedBiomapperRead.sol/interface.IBridgedBiomapperRead.html
 
 ## Installation
@@ -46,7 +46,7 @@ yarn add @biomapper-sdk/core @biomapper-sdk/libraries @biomapper-sdk/events
 Import the dependencies from the `@biomapper-sdk` like this:
 
 ```solidity
-import {IBiomapperLogRead} from "@biomapper-sdk/core/IBiomapperLogRead.sol";
+import {IBiomapperRead} from "@biomapper-sdk/core/IBiomapperRead.sol";
 import {IBridgedBiomapperRead} from "@biomapper-sdk/core/IBridgedBiomapperRead.sol";
 import {BiomapperLogLib} from "@biomapper-sdk/libraries/BiomapperLogLib.sol";
 ```
@@ -62,7 +62,7 @@ forge install humanode-network/biomapper-sdk
 Import the dependencies from `biomapper-sdk` like this:
 
 ```solidity
-import {IBiomapperLogRead} from "biomapper-sdk/core/IBiomapperLogRead.sol";
+import {IBiomapperRead} from "biomapper-sdk/core/IBiomapperRead.sol";
 import {IBridgedBiomapperRead} from "biomapper-sdk/core/IBridgedBiomapperRead.sol";
 import {BiomapperLogLib} from "biomapper-sdk/libraries/BiomapperLogLib.sol";
 ```

--- a/core/IBiomapperRead.sol
+++ b/core/IBiomapperRead.sol
@@ -8,7 +8,7 @@ pragma solidity ^0.8.20;
 /// #### Examples
 ///
 /// See the [BiomapperLogExamples](../../usage/BiomapperLogExamples.sol/contract.BiomapperLogExamples.html).
-interface IBiomapperLogRead {
+interface IBiomapperRead {
     /// @notice Structure representing a biomapper generation as an element of a doubly linked list.
     ///
     /// @notice Pointer of {Generation} is a number of block that contains a 'generation change' transaction.

--- a/core/IBiomapperRead.sol
+++ b/core/IBiomapperRead.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-/// @dev Interface for the `BiomapperLog` contract.
+/// @dev Interface for the `Biomapper` contract.
 /// @notice View historical biomapping state for a given account,
 /// and overall generation changes.
 ///
 /// #### Examples
 ///
-/// See the [BiomapperLogExamples](../../usage/BiomapperLogExamples.sol/contract.BiomapperLogExamples.html).
+/// See the [BiomapperExamples](../../usage/BiomapperExamples.sol/contract.BiomapperExamples.html).
 interface IBiomapperRead {
     /// @notice Structure representing a biomapper generation as an element of a doubly linked list.
     ///

--- a/examples/sybil-resistant-airdrop/contracts/SybilResistantAirdrop.sol
+++ b/examples/sybil-resistant-airdrop/contracts/SybilResistantAirdrop.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 import {IBiomapperRead} from "@biomapper-sdk/core/IBiomapperRead.sol";
-import {BiomapperLogLib} from "@biomapper-sdk/libraries/BiomapperLogLib.sol";
+import {BiomapperLib} from "@biomapper-sdk/libraries/BiomapperLib.sol";
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -13,12 +13,12 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
  */
 contract SybilResistantAirdrop {
     using SafeERC20 for IERC20;
-    using BiomapperLogLib for IBiomapperRead;
+    using BiomapperLib for IBiomapperRead;
 
     IERC20 public immutable ERC20_TOKEN; // The ERC20 token being airdropped
     address public immutable TOKEN_VAULT; // The address holding the tokens for the airdrop
     uint256 public immutable AMOUNT_PER_USER; // The amount of tokens each user can claim
-    IBiomapperRead public immutable BIOMAPPER_LOG; // The contract for checking uniqueness of users
+    IBiomapperRead public immutable BIOMAPPER; // The contract for checking uniqueness of users
 
     mapping(address => bool) public isAlreadyClaimed; // Mapping to track claimed users
 
@@ -27,18 +27,18 @@ contract SybilResistantAirdrop {
      * @param tokenAddress The address of the ERC20 token being airdropped.
      * @param tokenVault The address holding the tokens for the airdrop.
      * @param amountPerUser The amount of tokens each user can claim.
-     * @param biomapperLogAddress The address of the contract for checking uniqueness of users.
+     * @param biomapperAddress The address of the contract for checking uniqueness of users.
      */
     constructor(
         address tokenAddress,
         address tokenVault,
         uint256 amountPerUser,
-        address biomapperLogAddress
+        address biomapperAddress
     ) {
         ERC20_TOKEN = IERC20(tokenAddress);
         TOKEN_VAULT = tokenVault;
         AMOUNT_PER_USER = amountPerUser;
-        BIOMAPPER_LOG = IBiomapperRead(biomapperLogAddress);
+        BIOMAPPER = IBiomapperRead(biomapperAddress);
     }
 
     /**
@@ -52,7 +52,7 @@ contract SybilResistantAirdrop {
      */
     function claim() public {
         require(!isAlreadyClaimed[msg.sender], "User has already claimed");
-        require(BIOMAPPER_LOG.isUnique(msg.sender), "User is not unique");
+        require(BIOMAPPER.isUnique(msg.sender), "User is not unique");
 
         ERC20_TOKEN.safeTransferFrom(TOKEN_VAULT, msg.sender, AMOUNT_PER_USER);
 

--- a/examples/sybil-resistant-airdrop/contracts/SybilResistantAirdrop.sol
+++ b/examples/sybil-resistant-airdrop/contracts/SybilResistantAirdrop.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IBiomapperLogRead} from "@biomapper-sdk/core/IBiomapperLogRead.sol";
+import {IBiomapperRead} from "@biomapper-sdk/core/IBiomapperRead.sol";
 import {BiomapperLogLib} from "@biomapper-sdk/libraries/BiomapperLogLib.sol";
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -13,12 +13,12 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
  */
 contract SybilResistantAirdrop {
     using SafeERC20 for IERC20;
-    using BiomapperLogLib for IBiomapperLogRead;
+    using BiomapperLogLib for IBiomapperRead;
 
     IERC20 public immutable ERC20_TOKEN; // The ERC20 token being airdropped
     address public immutable TOKEN_VAULT; // The address holding the tokens for the airdrop
     uint256 public immutable AMOUNT_PER_USER; // The amount of tokens each user can claim
-    IBiomapperLogRead public immutable BIOMAPPER_LOG; // The contract for checking uniqueness of users
+    IBiomapperRead public immutable BIOMAPPER_LOG; // The contract for checking uniqueness of users
 
     mapping(address => bool) public isAlreadyClaimed; // Mapping to track claimed users
 
@@ -38,7 +38,7 @@ contract SybilResistantAirdrop {
         ERC20_TOKEN = IERC20(tokenAddress);
         TOKEN_VAULT = tokenVault;
         AMOUNT_PER_USER = amountPerUser;
-        BIOMAPPER_LOG = IBiomapperLogRead(biomapperLogAddress);
+        BIOMAPPER_LOG = IBiomapperRead(biomapperLogAddress);
     }
 
     /**

--- a/examples/sybil-resistant-staking/contracts/SybilResistantStaking.sol
+++ b/examples/sybil-resistant-staking/contracts/SybilResistantStaking.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IBiomapperLogRead} from "@biomapper-sdk/core/IBiomapperLogRead.sol";
+import {IBiomapperRead} from "@biomapper-sdk/core/IBiomapperRead.sol";
 import {BiomapperLogLib} from "@biomapper-sdk/libraries/BiomapperLogLib.sol";
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -9,13 +9,13 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 
 contract SybilResistantStaking {
     using SafeERC20 for IERC20;
-    using BiomapperLogLib for IBiomapperLogRead;
+    using BiomapperLogLib for IBiomapperRead;
 
     IERC20 public immutable STAKING_TOKEN;
     IERC20 public immutable REWARD_TOKEN;
     address public immutable REWARD_TOKEN_VAULT;
     uint256 public immutable PERCENT_MULTIPLIER;
-    IBiomapperLogRead public immutable BIOMAPPER_LOG;
+    IBiomapperRead public immutable BIOMAPPER_LOG;
 
     mapping(address => uint256) public amountDeposited;
     mapping(address => uint256) public depositedAt;
@@ -31,7 +31,7 @@ contract SybilResistantStaking {
         REWARD_TOKEN = IERC20(rewardTokenAddress);
         REWARD_TOKEN_VAULT = rewardTokenVault;
         PERCENT_MULTIPLIER = percentMultiplier;
-        BIOMAPPER_LOG = IBiomapperLogRead(biomapperLogAddress);
+        BIOMAPPER_LOG = IBiomapperRead(biomapperLogAddress);
     }
 
     modifier mustBeUnique() {

--- a/examples/sybil-resistant-staking/contracts/SybilResistantStaking.sol
+++ b/examples/sybil-resistant-staking/contracts/SybilResistantStaking.sol
@@ -2,20 +2,20 @@
 pragma solidity ^0.8.20;
 
 import {IBiomapperRead} from "@biomapper-sdk/core/IBiomapperRead.sol";
-import {BiomapperLogLib} from "@biomapper-sdk/libraries/BiomapperLogLib.sol";
+import {BiomapperLib} from "@biomapper-sdk/libraries/BiomapperLib.sol";
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 contract SybilResistantStaking {
     using SafeERC20 for IERC20;
-    using BiomapperLogLib for IBiomapperRead;
+    using BiomapperLib for IBiomapperRead;
 
     IERC20 public immutable STAKING_TOKEN;
     IERC20 public immutable REWARD_TOKEN;
     address public immutable REWARD_TOKEN_VAULT;
     uint256 public immutable PERCENT_MULTIPLIER;
-    IBiomapperRead public immutable BIOMAPPER_LOG;
+    IBiomapperRead public immutable BIOMAPPER;
 
     mapping(address => uint256) public amountDeposited;
     mapping(address => uint256) public depositedAt;
@@ -25,17 +25,17 @@ contract SybilResistantStaking {
         address rewardTokenAddress,
         address rewardTokenVault,
         uint256 percentMultiplier,
-        address biomapperLogAddress
+        address biomapperAddress
     ) {
         STAKING_TOKEN = IERC20(stakingTokenAddress);
         REWARD_TOKEN = IERC20(rewardTokenAddress);
         REWARD_TOKEN_VAULT = rewardTokenVault;
         PERCENT_MULTIPLIER = percentMultiplier;
-        BIOMAPPER_LOG = IBiomapperRead(biomapperLogAddress);
+        BIOMAPPER = IBiomapperRead(biomapperAddress);
     }
 
     modifier mustBeUnique() {
-        require(BIOMAPPER_LOG.isUnique(msg.sender), "User is not unique");
+        require(BIOMAPPER.isUnique(msg.sender), "User is not unique");
         _;
     }
 
@@ -59,7 +59,7 @@ contract SybilResistantStaking {
         uint256 stakedAmount = amountDeposited[msg.sender];
 
         uint256 rewardAmount = (stakedAmount *
-            BIOMAPPER_LOG.countBiomappedBlocks({
+            BIOMAPPER.countBiomappedBlocks({
                 who: msg.sender,
                 fromBlock: depositedAt[msg.sender]
             }) *

--- a/libraries/BiomapperLib.sol
+++ b/libraries/BiomapperLib.sol
@@ -3,20 +3,20 @@ pragma solidity ^0.8.20;
 
 import {IBiomapperRead} from "@biomapper-sdk/core/IBiomapperRead.sol";
 
-/// @notice A utility library for the `BiomapperLog` contract.
-library BiomapperLogLib {
+/// @notice A utility library for the `Biomapper` contract.
+library BiomapperLib {
     /// @notice Determines the uniqueness status of a given address in the current biomapper generation.
     /// The alternative way of using the `Biomapper` contract.
-    /// @param biomapperLog The `BiomapperLog` contract.
+    /// @param biomapper The `Biomapper` contract.
     /// @param who The address to check for uniqueness.
     /// @return A boolean value indicating whether the address is biomapped (true) or not (false).
     function isUnique(
-        IBiomapperRead biomapperLog,
+        IBiomapperRead biomapper,
         address who
     ) external view returns (bool) {
-        uint256 currentGeneration = biomapperLog.generationsHead();
+        uint256 currentGeneration = biomapper.generationsHead();
 
-        uint256 biomappedAt = biomapperLog.generationBiomapping({
+        uint256 biomappedAt = biomapper.generationBiomapping({
             account: who,
             generationPtr: currentGeneration
         });
@@ -25,21 +25,21 @@ library BiomapperLogLib {
     }
 
     /// @notice Counts the number of blocks a user has been biomapped for.
-    /// @param biomapperLog The `BiomapperLog` contract.
+    /// @param biomapper The `Biomapper` contract.
     /// @param who The address to count.
     /// @param fromBlock The starting block number.
     /// @return blocks The number of blocks the user has been biomapped for.
     function countBiomappedBlocks(
-        IBiomapperRead biomapperLog,
+        IBiomapperRead biomapper,
         address who,
         uint256 fromBlock
     ) public view returns (uint256 blocks) {
-        uint256 generation = biomapperLog.generationsHead();
+        uint256 generation = biomapper.generationsHead();
         uint256 to = block.number;
         uint256 from;
 
         while (true) {
-            from = biomapperLog.generationBiomapping({
+            from = biomapper.generationBiomapping({
                 account: who,
                 generationPtr: generation
             });
@@ -54,47 +54,47 @@ library BiomapperLogLib {
 
             to = generation;
 
-            generation = biomapperLog
+            generation = biomapper
                 .generationsListItem({ptr: generation})
                 .prevPtr;
         }
     }
 
     /// @notice Finds the first generation a user was biomapped in.
-    /// @param biomapperLog The `BiomapperLog` contract.
+    /// @param biomapper The `Biomapper` contract.
     /// @param who The address to check.
     /// @return The block number of the first biomapping for the user, or 0 if never biomapped.
     function firstBiomappedGeneration(
-        IBiomapperRead biomapperLog,
+        IBiomapperRead biomapper,
         address who
     ) external view returns (uint256) {
-        uint256 firstBiomap = biomapperLog.biomappingsTail({account: who});
+        uint256 firstBiomap = biomapper.biomappingsTail({account: who});
 
         if (firstBiomap == 0) {
             return 0;
         }
 
         return
-            biomapperLog
+            biomapper
                 .biomappingsListItem({account: who, ptr: firstBiomap})
                 .generationPtr;
     }
 
     /// @notice Finds the block number of the oldest sequential biomapping for a user.
-    /// @param biomapperLog The `BiomapperLog` contract.
+    /// @param biomapper The `Biomapper` contract.
     /// @param who The address of the user to check.
     /// @return The block number of the oldest sequential biomapping for the user,
     /// or 0 if not biomapped in the current generation.
     function firstSequentialBiomappedGeneration(
-        IBiomapperRead biomapperLog,
+        IBiomapperRead biomapper,
         address who
     ) external view returns (uint256) {
-        uint256 generation = biomapperLog.generationsHead();
+        uint256 generation = biomapper.generationsHead();
 
         uint256 oldestSequentialBiomappedAt;
 
         while (true) {
-            uint256 oldestSequentialBiomappedAtCandidate = biomapperLog
+            uint256 oldestSequentialBiomappedAtCandidate = biomapper
                 .generationBiomapping({
                     account: who,
                     generationPtr: generation
@@ -106,7 +106,7 @@ library BiomapperLogLib {
 
             oldestSequentialBiomappedAt = oldestSequentialBiomappedAtCandidate;
 
-            generation = biomapperLog
+            generation = biomapper
                 .generationsListItem({ptr: generation})
                 .prevPtr;
 

--- a/libraries/BiomapperLogLib.sol
+++ b/libraries/BiomapperLogLib.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IBiomapperLogRead} from "@biomapper-sdk/core/IBiomapperLogRead.sol";
+import {IBiomapperRead} from "@biomapper-sdk/core/IBiomapperRead.sol";
 
 /// @notice A utility library for the `BiomapperLog` contract.
 library BiomapperLogLib {
@@ -11,7 +11,7 @@ library BiomapperLogLib {
     /// @param who The address to check for uniqueness.
     /// @return A boolean value indicating whether the address is biomapped (true) or not (false).
     function isUnique(
-        IBiomapperLogRead biomapperLog,
+        IBiomapperRead biomapperLog,
         address who
     ) external view returns (bool) {
         uint256 currentGeneration = biomapperLog.generationsHead();
@@ -30,7 +30,7 @@ library BiomapperLogLib {
     /// @param fromBlock The starting block number.
     /// @return blocks The number of blocks the user has been biomapped for.
     function countBiomappedBlocks(
-        IBiomapperLogRead biomapperLog,
+        IBiomapperRead biomapperLog,
         address who,
         uint256 fromBlock
     ) public view returns (uint256 blocks) {
@@ -65,7 +65,7 @@ library BiomapperLogLib {
     /// @param who The address to check.
     /// @return The block number of the first biomapping for the user, or 0 if never biomapped.
     function firstBiomappedGeneration(
-        IBiomapperLogRead biomapperLog,
+        IBiomapperRead biomapperLog,
         address who
     ) external view returns (uint256) {
         uint256 firstBiomap = biomapperLog.biomappingsTail({account: who});
@@ -86,7 +86,7 @@ library BiomapperLogLib {
     /// @return The block number of the oldest sequential biomapping for the user,
     /// or 0 if not biomapped in the current generation.
     function firstSequentialBiomappedGeneration(
-        IBiomapperLogRead biomapperLog,
+        IBiomapperRead biomapperLog,
         address who
     ) external view returns (uint256) {
         uint256 generation = biomapperLog.generationsHead();

--- a/mock/IMockBiomapperLogWrite.sol
+++ b/mock/IMockBiomapperLogWrite.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-/// @dev Interface for the `MockBiomapperLock` contract.
+/// @dev Interface for the `MockBiomapperLog` contract.
 /// @notice Mock access for writing biomapper log.
 interface IMockBiomapperLogWrite {
     /// @notice Initializes a new generation.

--- a/mock/MockBiomapperLog.sol
+++ b/mock/MockBiomapperLog.sol
@@ -66,7 +66,7 @@ contract MockBiomapperLog is IBiomapperRead, IMockBiomapperLogWrite {
     }
 
     /// @inheritdoc IMockBiomapperLogWrite
-    function initGeneration(bytes32 generation) external {
+    function initGeneration(bytes32 generation) public {
         uint256 prevPtr = generationsHead;
         require(
             prevPtr != block.number,
@@ -88,7 +88,7 @@ contract MockBiomapperLog is IBiomapperRead, IMockBiomapperLogWrite {
     }
 
     /// @inheritdoc IMockBiomapperLogWrite
-    function biomap(address account) external {
+    function biomap(address account) public {
         uint256 generationPtr = generationsHead;
         require(generationPtr != 0, "generation must be initialized");
 

--- a/mock/MockBiomapperLog.sol
+++ b/mock/MockBiomapperLog.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 import {IMockBiomapperLogWrite} from "./IMockBiomapperLogWrite.sol";
-import {IBiomapperLogRead} from "@biomapper-sdk/core/IBiomapperLogRead.sol";
+import {IBiomapperRead} from "@biomapper-sdk/core/IBiomapperRead.sol";
 
 /// @notice Mock contract implementing `BiomapperLog` contract interfaces.
 ///
@@ -16,7 +16,7 @@ import {IBiomapperLogRead} from "@biomapper-sdk/core/IBiomapperLogRead.sol";
 ///
 /// @notice When deployed independently, use the `IMockBiomapperLogWrite`
 /// interface to drive the state.
-contract MockBiomapperLog is IBiomapperLogRead, IMockBiomapperLogWrite {
+contract MockBiomapperLog is IBiomapperRead, IMockBiomapperLogWrite {
     uint256 public generationsHead;
     uint256 public generationsTail;
     mapping(uint256 => Generation) public generationsList;
@@ -28,21 +28,21 @@ contract MockBiomapperLog is IBiomapperLogRead, IMockBiomapperLogWrite {
     mapping(address => mapping(uint256 => uint256))
         public generationBiomappings;
 
-    /// @inheritdoc IBiomapperLogRead
+    /// @inheritdoc IBiomapperRead
     function biomappingsHead(
         address account
     ) external view override returns (uint256) {
         return biomappingsHeads[account];
     }
 
-    /// @inheritdoc IBiomapperLogRead
+    /// @inheritdoc IBiomapperRead
     function biomappingsTail(
         address account
     ) external view override returns (uint256) {
         return biomappingsTails[account];
     }
 
-    /// @inheritdoc IBiomapperLogRead
+    /// @inheritdoc IBiomapperRead
     function biomappingsListItem(
         address account,
         uint256 ptr
@@ -50,14 +50,14 @@ contract MockBiomapperLog is IBiomapperLogRead, IMockBiomapperLogWrite {
         return biomappingsLists[account][ptr];
     }
 
-    /// @inheritdoc IBiomapperLogRead
+    /// @inheritdoc IBiomapperRead
     function generationsListItem(
         uint256 ptr
     ) external view override returns (Generation memory) {
         return generationsList[ptr];
     }
 
-    /// @inheritdoc IBiomapperLogRead
+    /// @inheritdoc IBiomapperRead
     function generationBiomapping(
         address account,
         uint256 generationPtr

--- a/tests/hardhat/contracts/CanImport.sol
+++ b/tests/hardhat/contracts/CanImport.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.24;
 
-import {IBiomapperLogRead} from "@biomapper-sdk/core/IBiomapperLogRead.sol";
+import {IBiomapperRead} from "@biomapper-sdk/core/IBiomapperRead.sol";
 import {BiomapperLogLib} from "@biomapper-sdk/libraries/BiomapperLogLib.sol";
 import {IGenerationChangeEvents} from "@biomapper-sdk/events/IGenerationChangeEvents.sol";
 import {IProveUniquenessEvents} from "@biomapper-sdk/events/IProveUniquenessEvents.sol";

--- a/tests/hardhat/contracts/CanImport.sol
+++ b/tests/hardhat/contracts/CanImport.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {IBiomapperRead} from "@biomapper-sdk/core/IBiomapperRead.sol";
-import {BiomapperLogLib} from "@biomapper-sdk/libraries/BiomapperLogLib.sol";
+import {BiomapperLib} from "@biomapper-sdk/libraries/BiomapperLib.sol";
 import {IGenerationChangeEvents} from "@biomapper-sdk/events/IGenerationChangeEvents.sol";
 import {IProveUniquenessEvents} from "@biomapper-sdk/events/IProveUniquenessEvents.sol";
 import {MockBiomapper} from "@biomapper-sdk/mock/MockBiomapper.sol";

--- a/tests/hardhat/test/MockBiomapper.ts
+++ b/tests/hardhat/test/MockBiomapper.ts
@@ -233,7 +233,7 @@ describe("MockBiomapper", () => {
     });
   });
 
-  describe("IBiomapperLogRead", () => {
+  describe("IBiomapperRead", () => {
     describe("#generationsHead", () => {
       context("on deploy", () => {
         it("is initialized", async () => {

--- a/usage/BiomapperLogExamples.sol
+++ b/usage/BiomapperLogExamples.sol
@@ -3,39 +3,37 @@ pragma solidity ^0.8.20;
 
 import {IBiomapperRead} from "@biomapper-sdk/core/IBiomapperRead.sol";
 
-/// @dev Usage examples for the `BiomapperLog` contract.
-/// @notice Here are the usage examples for the `BiomapperLog` contract.
+/// @dev Usage examples for the `Biomapper` contract.
+/// @notice Here are the usage examples for the `Biomapper` contract.
 ///
-/// `BiomapperLog` exposes historical state of biomapping and generation
+/// `Biomapper` exposes historical state of biomapping and generation
 /// changes.
 ///
 /// ### Note
 ///
 /// If you are viewing this though the documentation, you should instead open
 /// the full source code of this file to see the contents of the functions.
-contract BiomapperLogExamples {
-    /// @notice Assume this is the address of the `BiomapperLog` contract.
+contract BiomapperExamples {
+    /// @notice Assume this is the address of the `Biomapper` contract.
     /// You can find the actual address in the documentation.
-    address public immutable BIOMAPPER_LOG_CONTRACT_ADDRESS;
+    address public immutable BIOMAPPER_CONTRACT_ADDRESS;
 
     /// @notice A loop through all generations.
     /// @dev Go to the source code if you are viewing this though
     /// the documentation.
     function example1() external view {
         // Activate the interface.
-        IBiomapperRead biomapperLog = IBiomapperRead(
-            BIOMAPPER_LOG_CONTRACT_ADDRESS
-        );
+        IBiomapperRead biomapper = IBiomapperRead(BIOMAPPER_CONTRACT_ADDRESS);
 
         // Take the latest (aka current) generation.
-        uint256 generation = biomapperLog.generationsHead();
+        uint256 generation = biomapper.generationsHead();
 
         while (true) {
             // Do something with a generation.
 
             // Move to the previous generation - i.e in the newest to oldest
             // direction.
-            generation = biomapperLog
+            generation = biomapper
                 .generationsListItem({ptr: generation})
                 .prevPtr;
 
@@ -52,19 +50,17 @@ contract BiomapperLogExamples {
     /// the documentation.
     function example2() external view {
         // Activate the interface.
-        IBiomapperRead biomapperLog = IBiomapperRead(
-            BIOMAPPER_LOG_CONTRACT_ADDRESS
-        );
+        IBiomapperRead biomapper = IBiomapperRead(BIOMAPPER_CONTRACT_ADDRESS);
 
         // Take the oldest (aka first) generation.
-        uint256 generation = biomapperLog.generationsTail();
+        uint256 generation = biomapper.generationsTail();
 
         while (true) {
             // Do something with a generation.
 
             // Move to the next generation - i.e. in the oldest to newest
             // direction.
-            generation = biomapperLog
+            generation = biomapper
                 .generationsListItem({ptr: generation})
                 .nextPtr;
 

--- a/usage/BiomapperLogExamples.sol
+++ b/usage/BiomapperLogExamples.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {IBiomapperLogRead} from "@biomapper-sdk/core/IBiomapperLogRead.sol";
+import {IBiomapperRead} from "@biomapper-sdk/core/IBiomapperRead.sol";
 
 /// @dev Usage examples for the `BiomapperLog` contract.
 /// @notice Here are the usage examples for the `BiomapperLog` contract.
@@ -23,7 +23,7 @@ contract BiomapperLogExamples {
     /// the documentation.
     function example1() external view {
         // Activate the interface.
-        IBiomapperLogRead biomapperLog = IBiomapperLogRead(
+        IBiomapperRead biomapperLog = IBiomapperRead(
             BIOMAPPER_LOG_CONTRACT_ADDRESS
         );
 
@@ -52,7 +52,7 @@ contract BiomapperLogExamples {
     /// the documentation.
     function example2() external view {
         // Activate the interface.
-        IBiomapperLogRead biomapperLog = IBiomapperLogRead(
+        IBiomapperRead biomapperLog = IBiomapperRead(
             BIOMAPPER_LOG_CONTRACT_ADDRESS
         );
 


### PR DESCRIPTION
This PR simplifies the mental model of the user-perceived API by trying to present the `BiomapperLog` as the `Biomapper` contract.

This PR has a few issues though:
- the events are not sent from the `Biomapper` (ex `BiomapperLog`) in actuality, but from the different address - this is an issue with the overall approach, and needs to be handled properly by a more sound design
- the mock still doesn't follow the pattern, and exposes the `MockBiomapper` and `MockBiomapperLog`